### PR TITLE
Handle out of band tag delete in resourceAwsEc2TagRead

### DIFF
--- a/aws/resource_aws_ec2_tag.go
+++ b/aws/resource_aws_ec2_tag.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -10,6 +11,19 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
+
+type ResourceNotExists struct {
+	message string
+}
+
+func NewResourceNotExists(message string) *ResourceNotExists {
+	return &ResourceNotExists{
+		message: message,
+	}
+}
+func (e *ResourceNotExists) Error() string {
+	return e.message
+}
 
 func resourceAwsEc2Tag() *schema.Resource {
 	return &schema.Resource{
@@ -103,20 +117,30 @@ func resourceAwsEc2TagRead(d *schema.ResourceData, meta interface{}) error {
 			},
 		})
 
-		// tag not found _yet_
-		if len(tags.Tags) == 0 {
-			return resource.RetryableError(fmt.Errorf("tag not found"))
-		}
-
 		if err != nil {
 			return resource.RetryableError(err)
+		}
+
+		// tag not found _yet_
+		if len(tags.Tags) == 0 {
+			return resource.RetryableError(NewResourceNotExists("tag not found"))
 		}
 
 		return nil
 	})
 
 	if retryError != nil {
-		return fmt.Errorf("[ERROR] Tag %s not found on resource %s", key, id)
+		if _, ok := retryError.(*ResourceNotExists); !ok {
+			return fmt.Errorf("[ERROR] Could not read tag %s on resource %s", key, id)
+		}
+	}
+
+	if len(tags.Tags) == 0 {
+		// The API call did not fail but the tag does not exists on resource
+		// Did not find the tag, as per contract with TF report:https://www.terraform.io/docs/extend/writing-custom-providers.html
+		log.Printf("There are no tags on resource %s", id)
+		d.SetId("")
+		return nil
 	}
 
 	if len(tags.Tags) != 1 {

--- a/aws/resource_aws_ec2_tag.go
+++ b/aws/resource_aws_ec2_tag.go
@@ -138,7 +138,7 @@ func resourceAwsEc2TagRead(d *schema.ResourceData, meta interface{}) error {
 	if len(tags.Tags) == 0 {
 		// The API call did not fail but the tag does not exists on resource
 		// Did not find the tag, as per contract with TF report:https://www.terraform.io/docs/extend/writing-custom-providers.html
-		log.Printf("There are no tags on resource %s", id)
+		log.Printf("[WARN]There are no tags on resource %s", id)
 		d.SetId("")
 		return nil
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
hpamukcu-ltm:terraform-provider-aws hpamukcu$ make testacc TESTARGS='-run=TestAccAWSEc2ResourceTag*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEc2ResourceTag* -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEc2ResourceTag_basic
=== PAUSE TestAccAWSEc2ResourceTag_basic
=== RUN   TestAccAWSEc2ResourceTag_subnet
=== PAUSE TestAccAWSEc2ResourceTag_subnet
=== RUN   TestAccAWSEc2ResourceTag_out_of_band_delete
=== PAUSE TestAccAWSEc2ResourceTag_out_of_band_delete
=== CONT  TestAccAWSEc2ResourceTag_basic
=== CONT  TestAccAWSEc2ResourceTag_out_of_band_delete
=== CONT  TestAccAWSEc2ResourceTag_subnet
--- PASS: TestAccAWSEc2ResourceTag_basic (21.67s)
--- PASS: TestAccAWSEc2ResourceTag_subnet (24.10s)
--- PASS: TestAccAWSEc2ResourceTag_out_of_band_delete (40.03s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       40.109s

```

### Problem
When tags are removed outside tf state, after they are added, if Read operation finds that they do not exist it needs to be reported back as part of the documentation: https://www.terraform.io/docs/extend/writing-custom-providers.html

Otherwise, we keep getting error "Expected exactly 1 tag, got 0 tags"

Another fix made in this PR is the order of the check for err from describetags and using the value tags. 

### Test
Added acceptance test for this scenario and also checked coverage
