### PR TITLE
some bugfixes

### DIFF
--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -122,7 +122,7 @@ func resourceAwsGlueJob() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"allocated_capacity", "max_capacity"},
-				ValidateFunc:  validation.StringInSlice([]string{
+				ValidateFunc: validation.StringInSlice([]string{
 					glue.WorkerTypeG1x,
 					glue.WorkerTypeG2x,
 					glue.WorkerTypeStandard,

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -250,16 +250,14 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("arn", subnet.SubnetArn)
 
-	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(subnet.Tags).IgnoreAws().IgnorePrefixes(ignoreTagPrefixes).Ignore(ignoreTags).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+	_, tagsAreDefined := d.GetOk("tags")
+	if tagsAreDefined {
+		if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(subnet.Tags).IgnoreAws().IgnorePrefixes(ignoreTagPrefixes).Ignore(ignoreTags).Map()); err != nil {
+			return fmt.Errorf("error setting tags: %s", err)
+		}
 	}
 
 	d.Set("owner_id", subnet.OwnerId)
-
-	_, tagsAreDefined := d.GetOk("tags")
-	if tagsAreDefined {
-		d.Set("tags", tagsToMap(subnet.Tags))
-	}
 
 	return nil
 }

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -296,8 +296,11 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	}.String()
 	d.Set("arn", arn)
 
-	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpc.Tags).IgnoreAws().IgnorePrefixes(ignoreTagPrefixes).Ignore(ignoreTags).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+	_, tagsAreDefined := d.GetOk("tags")
+	if tagsAreDefined {
+		if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpc.Tags).IgnoreAws().IgnorePrefixes(ignoreTagPrefixes).Ignore(ignoreTags).Map()); err != nil {
+			return fmt.Errorf("error setting tags: %s", err)
+		}
 	}
 
 	d.Set("owner_id", vpc.OwnerId)


### PR DESCRIPTION
These are updates I've made to our fork of the AWS provider as a result of a couple bugs we've run into.

One issue is that VPC and Subnet tags created by the `aws_ec2_tag` resource on one Terraform run will get deleted on the next run. On this second run, the `aws_ec2_tag` resource sees that the correct tag exists, so it does nothing. But the VPC or Subnet resource sees the tags created by `aws_ec2_tag` as tags that shouldn't belong because the tag isn't defined within the VPC or Subnet resource. This looks like an issue that has been solved in the past for VPCs, Subnets, and Route Tables, but this fix was eventually lost for VPCs and Subnets.

The other issue stems from the first. If a tag that's in Terraform state doesn't actually exist in AWS, the eventual consistency logic that was in `resourceAwsEc2TagRead()` would wait a while before determining that the tag needed to be created. This logic is appropriate for `resourceAwsEc2TagCreate()` but not for `resourceAwsEc2TagRead()`, so I moved it. Before this change, if a second Terraform run mistakenly deleted a tag that should exist, the next run after it would take a long time because it waits a while before believing that the tag doesn't exist.

I've tested this by re-running Terraform runs in our system, and the tags behave properly again. The only thing I haven't tested is whether the code works for new resources. I only just realized how I could test this in our own system without breaking other things, so I'll be doing that next. I may end up making minor changes to fix any issue I come across, but this is otherwise ready for review.