### PR TITLE
fixing broken tests for new tagging mechanism for VPC, subnet, and ro…

### DIFF
--- a/aws/resource_aws_route_table.go
+++ b/aws/resource_aws_route_table.go
@@ -231,9 +231,9 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	// Tags
 	_, tagsAreDefined := d.GetOk("tags")
 	if tagsAreDefined {
-    if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(rt.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-      return fmt.Errorf("error setting tags: %s", err)
-    }
+		if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(rt.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+			return fmt.Errorf("error setting tags: %s", err)
+		}
 	}
 
 	d.Set("owner_id", rt.OwnerId)

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -260,6 +260,11 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 			{
 				Config: testAccRouteTableConfigTagsUpdate,

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -236,9 +236,9 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	_, tagsAreDefined := d.GetOk("tags")
 	if tagsAreDefined {
-    if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(subnet.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-      return fmt.Errorf("error setting tags: %s", err)
-    }
+		if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(subnet.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+			return fmt.Errorf("error setting tags: %s", err)
+		}
 	}
 
 	d.Set("owner_id", subnet.OwnerId)

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -171,6 +171,11 @@ func TestAccAWSSubnet_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 		},
 	})
@@ -228,6 +233,11 @@ func TestAccAWSSubnet_ipv6(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 			{
 				Config: testAccSubnetConfigIpv6UpdateAssignIpv6OnCreation,
@@ -271,6 +281,11 @@ func TestAccAWSSubnet_enableIpv6(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 			{
 				Config: testAccSubnetConfigIpv6,
@@ -308,6 +323,11 @@ func TestAccAWSSubnet_availabilityZoneId(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 		},
 	})
@@ -344,6 +364,11 @@ func TestAccAWSSubnet_outpost(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 		},
 	})

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -262,9 +262,9 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 
 	_, tagsAreDefined := d.GetOk("tags")
 	if tagsAreDefined {
-  	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpc.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-	  	return fmt.Errorf("error setting tags: %s", err)
-    }
+		if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpc.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+			return fmt.Errorf("error setting tags: %s", err)
+		}
 	}
 
 	d.Set("owner_id", vpc.OwnerId)

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -131,6 +131,11 @@ func TestAccAWSVpc_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 		},
 	})
@@ -211,6 +216,11 @@ func TestAccAWSVpc_AssignGeneratedIpv6CidrBlock(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 			{
 				Config: testAccVpcConfigAssignGeneratedIpv6CidrBlock(false),
@@ -259,6 +269,11 @@ func TestAccAWSVpc_Tenancy(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 			{
 				Config: testAccVpcConfig,
@@ -304,6 +319,11 @@ func TestAccAWSVpc_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 			{
 				Config: testAccVpcConfigTagsUpdate,
@@ -483,6 +503,11 @@ func TestAccAWSVpc_bothDnsOptionsSet(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 		},
 	})
@@ -509,6 +534,11 @@ func TestAccAWSVpc_DisabledDnsSupport(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 		},
 	})
@@ -534,6 +564,11 @@ func TestAccAWSVpc_classiclinkOptionSet(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 		},
 	})
@@ -559,6 +594,11 @@ func TestAccAWSVpc_classiclinkDnsSupportOptionSet(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This is needed because we don't always call d.Set() in Read for tags as per
+					// https://github.com/hashicorp/terraform/pull/21019 and https://github.com/hashicorp/terraform/issues/20985
+					"tags",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

The main culprit behind the tests failure around tagging was first reported here: https://github.com/hashicorp/terraform/issues/20985. Essentially, there was a change in SDK with 0.12 that causes ImportStateVerify state tests to fail on resources if d.Set() is not called in Read, which is behavior added to the subnet, route_table, and vpc resources in regards to tags. More on this issue can be found here: https://github.com/hashicorp/terraform/pull/21019, though that does not really address the issue we ran into here.

One other thing to note, there is currently an initiative to return a call to `Read()` rather than `Update` on resources in their `Create()` functions.  `aws_route_table` has not yet been updated to this.  When it does, quite a few tests will break for that resource and will need to be fixed.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSVpc_'
--- PASS: TestAccAWSVpc_disappears (22.19s)
--- PASS: TestAccAWSVpc_coreMismatchedDiffs (29.51s)
--- PASS: TestAccAWSVpc_basic (32.20s)
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (33.63s)
--- PASS: TestAccAWSVpc_DisabledDnsSupport (34.75s)
--- PASS: TestAccAWSVpc_tags (54.57s)
--- PASS: TestAccAWSVpc_ignoreTags (56.39s)
--- PASS: TestAccAWSVpc_Tenancy (74.18s)
--- PASS: TestAccAWSVpc_AssignGeneratedIpv6CidrBlock (75.98s)
--- PASS: TestAccAWSVpc_update (79.10s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       80.753s
```
```
$ make testacc TESTARGS='-run=TestAccAWSSubnet'
--- PASS: TestAccAWSSubnet_availabilityZoneId (31.16s)
--- PASS: TestAccAWSSubnet_basic (32.12s)
--- PASS: TestAccAWSSubnet_enableIpv6 (51.00s)
--- PASS: TestAccAWSSubnet_ignoreTags (57.29s)
--- PASS: TestAccAWSSubnet_ipv6 (76.12s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       77.877s
```
```
$ make testacc TESTARGS='-run=TestAccAWSRouteTable'
--- PASS: TestAccAWSRouteTable_panicEmptyRoute (22.57s)
--- PASS: TestAccAWSRouteTable_ipv6 (40.95s)
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (51.54s)
--- PASS: TestAccAWSRouteTableAssociation_disappears (51.55s)
--- PASS: TestAccAWSRouteTable_vpcPeering (55.72s)
--- PASS: TestAccAWSRouteTableAssociation_Subnet_basic (57.10s)
--- PASS: TestAccAWSRouteTableAssociation_Gateway_basic (59.96s)
--- PASS: TestAccAWSRouteTable_basic (73.21s)
--- PASS: TestAccAWSRouteTableAssociation_Subnet_ChangeRouteTable (76.25s)
--- PASS: TestAccAWSRouteTableAssociation_Subnet_ChangeSubnet (77.59s)
--- PASS: TestAccAWSRouteTableAssociation_Gateway_ChangeRouteTable (78.38s)
--- PASS: TestAccAWSRouteTable_tags (89.54s)
--- PASS: TestAccAWSRouteTableAssociation_Gateway_ChangeGateway (90.94s)
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (96.93s)
--- PASS: TestAccAWSRouteTable_instance (115.10s)
--- PASS: TestAccAWSRouteTable_Route_TransitGatewayID (359.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       361.040s
```
```
$ make testacc TESTARGS='-run=TestAccAWSEc2ResourceTag'
--- PASS: TestAccAWSEc2ResourceTag_basic (25.55s)
--- PASS: TestAccAWSEc2ResourceTag_subnet (27.82s)
--- PASS: TestAccAWSEc2ResourceTag_out_of_band_delete (43.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       45.210s
```